### PR TITLE
Fix incorrect birthdate during user migration

### DIFF
--- a/app/Http/Livewire/Migrate.php
+++ b/app/Http/Livewire/Migrate.php
@@ -100,15 +100,21 @@ class Migrate extends Component
 
     public function updatedBirthdate()
     {
-        try {
-            $birthdate = Carbon::parse($this->birthdate);
-        } catch (InvalidFormatException $e) {
+        if (is_null($this->birthdate)) {
+            $this->birthdate_year = $this->birthdate_month = $this->birthdate_day = '';
+
             return;
         }
 
-        $this->birthdate_year = $birthdate->year;
-        $this->birthdate_month = $birthdate->month;
-        $this->birthdate_day = $birthdate->day;
+        try {
+            $birthdate = Carbon::parse($this->birthdate);
+
+            $this->birthdate_year = $birthdate->year;
+            $this->birthdate_month = $birthdate->month;
+            $this->birthdate_day = $birthdate->day;
+        } catch (InvalidFormatException $e) {
+            return;
+        }
     }
 
     protected function generateExpectedToken(): string

--- a/tests/Feature/MigrateUserTest.php
+++ b/tests/Feature/MigrateUserTest.php
@@ -192,6 +192,9 @@ class MigrateUserTest extends TestCase
             ->assertSet('class_course', '')
             ->assertSet('class_year', null)
             ->assertSet('birthdate', null)
+            ->assertSet('birthdate_year', '')
+            ->assertSet('birthdate_month', '')
+            ->assertSet('birthdate_day', '')
             ->assertSet('phone', null);
     }
 


### PR DESCRIPTION
Fix bug where birthdate was preset to an incorrect value during migration if user previously didn't have one set