### PR TITLE
Ensure a user always has a created_at timestamp

### DIFF
--- a/app/Imports/UsersImport.php
+++ b/app/Imports/UsersImport.php
@@ -25,7 +25,7 @@ class UsersImport extends LegacyDBImport implements ToModel, WithUpserts
             'gender' => 'U', // U for Unknown
             'email' => strtolower($row['email']),
             'created_at' => $row['joindate'] === 0
-                ? null
+                ? Carbon::create(2010)->toDateTimeString() // If the value is missing, just use 2010
                 : Carbon::createFromTimestamp($row['joindate'])->toDateTimeString(),
         ]);
 


### PR DESCRIPTION
We were encountering a situation where some migrated users didn't have a created_at timestamp, which could potentially cause bugs.
With this, those users will have a timestamp arbitrarily set to the beginning of 2010.