### PR TITLE
Fix issues with links in migrated posts

### DIFF
--- a/app/Traits/ParsesLegacyBBCode.php
+++ b/app/Traits/ParsesLegacyBBCode.php
@@ -156,6 +156,12 @@ trait ParsesLegacyBBCode
                 '$2'
             )
             ->addParser(
+                'namedlink',
+                '/\[url\="?(.*?)"?\](.*?)\[\/url\]/s',
+                '<a href="$1">$1</a>',
+                '$2'
+            )
+            ->addParser(
                 'email',
                 '/\[email\](.*?)\[\/email\]/s',
                 '<a href="mailto:$1">$1</a>',

--- a/app/Traits/ParsesLegacyBBCode.php
+++ b/app/Traits/ParsesLegacyBBCode.php
@@ -158,7 +158,7 @@ trait ParsesLegacyBBCode
             ->addParser(
                 'namedlink',
                 '/\[url\="?(.*?)"?\](.*?)\[\/url\]/s',
-                '<a href="$1">$1</a>',
+                '<a href="$1">$2</a>',
                 '$2'
             )
             ->addParser(


### PR DESCRIPTION
- Fix issue where BBCode `[URL]` tags where the value wasn't wrapped in `"` quotes resulted in empty hrefs.
- Update links to other threads so that they continue to function with the new site structure.