### PR TITLE
Subscriber paywall

### DIFF
--- a/app/Exceptions/UnsubscribedException.php
+++ b/app/Exceptions/UnsubscribedException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class UnsubscribedException extends Exception
+{
+    /**
+     * The path the user should be redirected to.
+     *
+     * @var string|null
+     */
+    protected ?string $redirectTo;
+
+    /**
+     * Create a new unsubscribed exception.
+     *
+     * @param  string  $message
+     * @param  string|null  $redirectTo
+     */
+    public function __construct($message = 'Subscription inactive.', string $redirectTo = null)
+    {
+        parent::__construct($message);
+
+        $this->redirectTo = $redirectTo;
+    }
+
+    /**
+     * Get the path the user should be redirected to.
+     *
+     * @return string|null
+     */
+    public function redirectTo(): ?string
+    {
+        return $this->redirectTo;
+    }
+}

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -22,10 +22,10 @@ class TagsController extends Controller
      * Display a listing of the resource.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  string  $type
+     * @param  string|null  $type
      * @return \Illuminate\Http\JsonResponse
      */
-    public function index(Request $request, string $type = null)
+    public function index(Request $request, string $type = null): \Illuminate\Http\JsonResponse
     {
         $request->validate([
             'query' => 'sometimes|string',

--- a/app/Http/Controllers/AttachmentsController.php
+++ b/app/Http/Controllers/AttachmentsController.php
@@ -15,7 +15,7 @@ class AttachmentsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware(['auth', 'verified']);
+        $this->middleware(['members-area', 'verified']);
     }
 
     /**

--- a/app/Http/Controllers/BestPostsController.php
+++ b/app/Http/Controllers/BestPostsController.php
@@ -8,6 +8,14 @@ use Illuminate\Http\Request;
 class BestPostsController extends Controller
 {
     /**
+     * Create a new controller instance.
+     */
+    public function __construct()
+    {
+        $this->middleware(['members-area']);
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * @param  \App\Models\Post  $post

--- a/app/Http/Controllers/CompaniesController.php
+++ b/app/Http/Controllers/CompaniesController.php
@@ -18,6 +18,7 @@ class CompaniesController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
+        $this->middleware('members-area')->only('index', 'show');
     }
 
     /**

--- a/app/Http/Controllers/FavoritesController.php
+++ b/app/Http/Controllers/FavoritesController.php
@@ -13,7 +13,7 @@ class FavoritesController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -11,7 +11,7 @@ class HomeController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/LockedThreadsController.php
+++ b/app/Http/Controllers/LockedThreadsController.php
@@ -14,7 +14,7 @@ class LockedThreadsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/PinnedThreadsController.php
+++ b/app/Http/Controllers/PinnedThreadsController.php
@@ -14,7 +14,7 @@ class PinnedThreadsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/PollResultsController.php
+++ b/app/Http/Controllers/PollResultsController.php
@@ -15,7 +15,7 @@ class PollResultsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/PollVotesController.php
+++ b/app/Http/Controllers/PollVotesController.php
@@ -17,7 +17,7 @@ class PollVotesController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/PollsController.php
+++ b/app/Http/Controllers/PollsController.php
@@ -19,7 +19,7 @@ class PollsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth')->except('index');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -19,7 +19,7 @@ class PostsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth')->except('index');
+        $this->middleware('members-area');
         $this->middleware('verified:threads,Tu dois vérifier ton adresse email avant de pouvoir poster.')
             ->only(['store']);
     }

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\UnsubscribedException;
 use App\Models\Activity;
 use App\Models\Profile;
 use App\Rules\ValidLocation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Response;
 
 class ProfilesController extends Controller
@@ -18,6 +20,7 @@ class ProfilesController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
+        $this->middleware('members-area')->only('index');
     }
 
     /**
@@ -46,9 +49,14 @@ class ProfilesController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @param  \App\Models\Profile  $profile
      * @return array|\Illuminate\View\View
+     * @throws \App\Exceptions\UnsubscribedException
      */
     public function show(Request $request, Profile $profile)
     {
+        if ($profile->id !== Auth::id() && ! Auth::user()->subscribed('default')) {
+            throw new UnsubscribedException;
+        }
+
         $data = [
             'profile' => $profile,
             'activities' => Activity::feed($profile),

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -8,6 +8,16 @@ use Illuminate\Http\Request;
 class SearchController extends Controller
 {
     /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('members-area');
+    }
+
+    /**
      * Display the search results.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/app/Http/Controllers/ThreadSubscriptionsController.php
+++ b/app/Http/Controllers/ThreadSubscriptionsController.php
@@ -13,7 +13,7 @@ class ThreadSubscriptionsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
     }
 
     /**

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -21,7 +21,7 @@ class ThreadsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('members-area');
         $this->middleware('verified:threads.index,Tu dois vérifier ton adresse email avant de pouvoir publier.')
             ->only(['create', 'store']);
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -42,6 +42,11 @@ class Kernel extends HttpKernel
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
+
+        'members-area' => [
+            \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
+            \App\Http\Middleware\EnsureUserIsSubscribed::class,
+        ],
     ];
 
     /**
@@ -58,6 +63,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'subscribed' => \App\Http\Middleware\EnsureUserIsSubscribed::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
     ];

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -67,4 +67,23 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
     ];
+
+    /**
+     * The priority-sorted list of middleware.
+     *
+     * Forces non-global middleware to always be in the given order.
+     *
+     * @var string[]
+     */
+    protected $middlewarePriority = [
+        \Illuminate\Cookie\Middleware\EncryptCookies::class,
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
+        \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        \Illuminate\Session\Middleware\AuthenticateSession::class,
+        \App\Http\Middleware\EnsureUserIsSubscribed::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
 }

--- a/app/Http/Middleware/EnsureUserIsSubscribed.php
+++ b/app/Http/Middleware/EnsureUserIsSubscribed.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Exceptions\UnsubscribedException;
 use Closure;
 use Illuminate\Http\Request;
 
@@ -13,13 +14,40 @@ class EnsureUserIsSubscribed
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @return mixed
+     * @throws \App\Exceptions\UnsubscribedException
      */
     public function handle(Request $request, Closure $next)
     {
         if ($request->user() && ! $request->user()->subscribed('default')) {
-            return redirect()->route('subscription.edit');
+            $this->unsubscribed($request);
         }
 
         return $next($request);
+    }
+
+    /**
+     * Get the path the user should be redirected to when they are not subscribed.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    protected function redirectTo($request)
+    {
+        if (! $request->expectsJson()) {
+            return route('subscription.edit');
+        }
+    }
+
+    /**
+     * Handle an unsubscribed user.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @throws \App\Exceptions\UnsubscribedException
+     */
+    protected function unsubscribed(Request $request)
+    {
+        throw new UnsubscribedException(
+            'Subscription inactive.', $this->redirectTo($request)
+        );
     }
 }

--- a/app/Http/Middleware/EnsureUserIsSubscribed.php
+++ b/app/Http/Middleware/EnsureUserIsSubscribed.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureUserIsSubscribed
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->user() && ! $request->user()->subscribed('default')) {
+            return redirect()->route('subscription.edit');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Policies/PagePolicy.php
+++ b/app/Policies/PagePolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Exceptions\UnsubscribedException;
 use App\Models\Page;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
@@ -34,11 +35,18 @@ class PagePolicy
      * @param  \App\Models\Page  $page
      * @return bool
      * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \App\Exceptions\UnsubscribedException
      */
     public function view(?User $user, Page $page): bool
     {
-        if ($page->restricted && is_null($user)) {
-            throw new AuthenticationException;
+        if ($page->restricted) {
+            if (is_null($user)) {
+                throw new AuthenticationException;
+            }
+
+            if (! $user->subscribed('default')) {
+                throw new UnsubscribedException;
+            }
         }
 
         if ($page->trashed()) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\Testing\Assert as PHPUnit;
+use Illuminate\Testing\TestResponse;
 use Illuminate\Validation\Rule;
 use Torann\GeoIP\Facades\GeoIP;
 
@@ -101,6 +103,17 @@ class AppServiceProvider extends ServiceProvider
             return Rule::phone()
                 ->detect() // Auto-detect country if country code supplied
                 ->country(['FR', GeoIP::getLocation(request()->ip())->iso_code]); // Fallback to France then GeoIP if unable to auto-detect)
+        });
+
+        TestResponse::macro('assertPaymentRequired', function () {
+            $actual = $this->getStatusCode();
+
+            PHPUnit::assertSame(
+                402, $actual,
+                "Response status code [{$actual}] is not a payment required status code."
+            );
+
+            return $this;
         });
 
         Validator::extend('not_present', function ($attribute, $value, $parameters, $validator) {

--- a/app/Traits/RecordsActivity.php
+++ b/app/Traits/RecordsActivity.php
@@ -43,6 +43,10 @@ trait RecordsActivity
      */
     protected function recordActivity($event): void
     {
+        if (Auth::guest()) {
+            return;
+        }
+
         $this->activity()->create([
             'user_id' => Auth::id(),
             'type' => $this->getActivityType($event),

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Laravel\Cashier\Subscription;
+
+class SubscriptionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Subscription::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => function () {
+                return User::factory()->create()->id;
+            },
+            'name' => 'default',
+            'stripe_id' => $this->faker->md5, // Random string
+            'stripe_status' => 'active',
+            'stripe_plan' => $this->faker->randomElement(config('council.plans')),
+            'quantity' => 1,
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -49,6 +49,18 @@ class UserFactory extends Factory
         ];
     }
 
+    /**
+     * Configure the model factory.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this->afterCreating(function (User $user) {
+            SubscriptionFactory::new()->create(['user_id' => $user->id]);
+        });
+    }
+
     public function unverifiedEmail()
     {
         return $this->state(function () {
@@ -56,5 +68,10 @@ class UserFactory extends Factory
                 'email_verified_at' => null,
             ];
         });
+    }
+
+    public function withoutSubscription()
+    {
+        return $this->newInstance(['afterCreating' => collect([])]);
     }
 }

--- a/resources/views/account/subscription.blade.php
+++ b/resources/views/account/subscription.blade.php
@@ -5,6 +5,8 @@
 @endsection
 
 @section('section_content')
+    @include('account.subscription.alert')
+
     @include('account.subscription.plans')
 
     @include('account.subscription.payment-methods')

--- a/resources/views/account/subscription/alert.blade.php
+++ b/resources/views/account/subscription/alert.blade.php
@@ -1,0 +1,10 @@
+@unless(Auth::user()->subscribed('default'))
+    <div class="alert alert-danger mb-5" role="alert">
+        <h4 class="alert-heading">Ta cotisation n’est pas à jour.</h4>
+        <p>Rejoins l’AGEPAC ci-dessous afin d’accéder à toutes les fonctionalités du site.</p>
+        <hr>
+        <p class="mb-0">
+            Si tu as des questions, n’hésite pas à <a href="{{ route('pages.show', 'contact') }}" class="alert-link">nous contacter</a>.
+        </p>
+    </div>
+@endunless

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -16,7 +16,7 @@ class AccountTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling()->signIn();
+        $this->withExceptionHandling()->signInUnsubscribed();
     }
 
     /** @test */

--- a/tests/Feature/AddAvatarTest.php
+++ b/tests/Feature/AddAvatarTest.php
@@ -9,10 +9,19 @@ use Tests\TestCase;
 
 class AddAvatarTest extends TestCase
 {
-    /** @test */
-    public function testOnlyMembersCanAddAvatars()
+    protected function setUp(): void
     {
-        $this->withExceptionHandling();
+        parent::setUp();
+
+        $this->withExceptionHandling()->signInUnsubscribed();
+
+        Storage::fake('public');
+    }
+
+    /** @test */
+    public function testGuestsCannotAddAvatars()
+    {
+        Auth::logout();
 
         $this->postJson(route('api.users.avatar.store', 1))
             ->assertStatus(401);
@@ -21,8 +30,6 @@ class AddAvatarTest extends TestCase
     /** @test */
     public function testAValidAvatarMustBeProvided()
     {
-        $this->withExceptionHandling()->signIn();
-
         $this->postJson(route('api.users.avatar.store', Auth::user()), [
             'avatar' => 'not-an-image',
         ])->assertStatus(422);
@@ -31,10 +38,6 @@ class AddAvatarTest extends TestCase
     /** @test */
     public function testAUserMayAddAnAvatarToTheirProfile()
     {
-        $this->signIn();
-
-        Storage::fake('public');
-
         $this->postJson(route('api.users.avatar.store', Auth::user()), [
             'avatar' => $file = UploadedFile::fake()->image('avatar.jpg'),
         ]);
@@ -47,10 +50,6 @@ class AddAvatarTest extends TestCase
     /** @test */
     public function testAddingANewAvatarDeletesTheOldOneFromDisk()
     {
-        $this->signIn();
-
-        Storage::fake('public');
-
         $this->postJson(route('api.users.avatar.store', Auth::user()), [
             'avatar' => $old_file = UploadedFile::fake()->image('old_avatar.jpg'),
         ]);

--- a/tests/Feature/BrowseCompaniesTest.php
+++ b/tests/Feature/BrowseCompaniesTest.php
@@ -25,7 +25,16 @@ class BrowseCompaniesTest extends TestCase
     }
 
     /** @test */
-    public function testUserCanViewCompany()
+    public function testUnsubscribedUserCannotViewCompany()
+    {
+        $this->signInUnsubscribed();
+
+        $this->showCompany()
+            ->assertPaymentRequired();
+    }
+
+    /** @test */
+    public function testSubscribedUserCanViewCompany()
     {
         $company = Company::factory()->create();
 

--- a/tests/Feature/BrowseProfilesTest.php
+++ b/tests/Feature/BrowseProfilesTest.php
@@ -16,7 +16,7 @@ class BrowseProfilesTest extends TestCase
     }
 
     /** @test */
-    public function testGuestCannotSearchProfiles()
+    public function testGuestsCannotBrowseProfiles()
     {
         Auth::logout();
 
@@ -25,7 +25,16 @@ class BrowseProfilesTest extends TestCase
     }
 
     /** @test */
-    public function testUserCanGetIndexOfProfiles()
+    public function testUnsubscribedUsersCannotBrowseProfiles()
+    {
+        $this->signInUnsubscribed();
+
+        $this->getJson(route('profiles.index'))
+            ->assertPaymentRequired();
+    }
+
+    /** @test */
+    public function testSubscribedUsersCanBrowseProfiles()
     {
         $profiles = Profile::factory()->count(10)->create();
 
@@ -67,19 +76,5 @@ class BrowseProfilesTest extends TestCase
 
         // Clean up index.
         Profile::latest()->take(4)->unsearchable();
-    }
-
-    /**
-     * Show the requested profile.
-     *
-     * @param  \App\Models\Profile  $profile
-     * @return \Illuminate\Testing\TestResponse
-     */
-    protected function showProfile(Profile $profile = null)
-    {
-        return $this->getJson(route(
-            'profiles.show',
-            $profile ?? Profile::factory()->create()
-        ));
     }
 }

--- a/tests/Feature/CreateCompanyTest.php
+++ b/tests/Feature/CreateCompanyTest.php
@@ -13,7 +13,7 @@ class CreateCompanyTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling()->signIn();
+        $this->withExceptionHandling()->signInUnsubscribed();
     }
 
     /** @test */
@@ -23,6 +23,19 @@ class CreateCompanyTest extends TestCase
 
         $this->storeCompany()
             ->assertUnauthorized();
+    }
+
+    /** @test */
+    public function testUserCanStoreCompany()
+    {
+        $data = Company::factory()->make()->setAppends([])->attributesToArray();
+
+        $this->storeCompany($data)
+            ->assertJsonMissingValidationErrors()
+            ->assertCreated()
+            ->assertJson($data);
+
+        $this->assertDatabaseHas('companies', $data);
     }
 
     /** @test */
@@ -163,19 +176,6 @@ class CreateCompanyTest extends TestCase
     {
         $this->storeCompany(['remarks' => str_repeat('*', 65536)])
             ->assertJsonValidationErrors('remarks');
-    }
-
-    /** @test */
-    public function testCanStoreCompany()
-    {
-        $data = Company::factory()->make()->setAppends([])->attributesToArray();
-
-        $this->storeCompany($data)
-            ->assertJsonMissingValidationErrors()
-            ->assertCreated()
-            ->assertJson($data);
-
-        $this->assertDatabaseHas('companies', $data);
     }
 
     /** @test */

--- a/tests/Feature/CreateCourseTest.php
+++ b/tests/Feature/CreateCourseTest.php
@@ -34,7 +34,7 @@ class CreateCourseTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling()->signIn();
+        $this->withExceptionHandling()->signInUnsubscribed();
     }
 
     /** @test */
@@ -44,6 +44,15 @@ class CreateCourseTest extends TestCase
 
         $this->storeCourse()
             ->assertUnauthorized();
+    }
+
+    /** @test */
+    public function testUserCanStoreCourse()
+    {
+        $this->storeCourse()
+            ->assertJsonMissingValidationErrors()
+            ->assertCreated()
+            ->assertJson($this->data);
     }
 
     /** @test */
@@ -189,15 +198,6 @@ class CreateCourseTest extends TestCase
     {
         $this->storeCourse(['description' => str_repeat('*', 65536)])
             ->assertJsonValidationErrors('description');
-    }
-
-    /** @test */
-    public function testCanStoreCourse()
-    {
-        $this->storeCourse()
-            ->assertJsonMissingValidationErrors()
-            ->assertCreated()
-            ->assertJson($this->data);
     }
 
     /**

--- a/tests/Feature/CreateOccupationTest.php
+++ b/tests/Feature/CreateOccupationTest.php
@@ -41,7 +41,7 @@ class CreateOccupationTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling()->signIn();
+        $this->withExceptionHandling()->signInUnsubscribed();
     }
 
     /** @test */
@@ -51,6 +51,15 @@ class CreateOccupationTest extends TestCase
 
         $this->storeOccupation()
             ->assertUnauthorized();
+    }
+
+    /** @test */
+    public function testUserCanStoreOccupation()
+    {
+        $this->storeOccupation()
+            ->assertJsonMissingValidationErrors()
+            ->assertCreated()
+            ->assertJson($this->data);
     }
 
     /** @test */
@@ -301,15 +310,6 @@ class CreateOccupationTest extends TestCase
             ->assertJson(['company' => $company->toArray()]);
 
         $this->assertDatabaseCount('companies', 1);
-    }
-
-    /** @test */
-    public function testCanStoreOccupation()
-    {
-        $this->storeOccupation()
-            ->assertJsonMissingValidationErrors()
-            ->assertCreated()
-            ->assertJson($this->data);
     }
 
     /**

--- a/tests/Feature/CreatePollTest.php
+++ b/tests/Feature/CreatePollTest.php
@@ -33,6 +33,15 @@ class CreatePollTest extends TestCase
     }
 
     /** @test */
+    public function testUnsubscribedUsersCannotAttachPollToThread()
+    {
+        $this->signInUnsubscribed();
+
+        $this->attachPollToThread()
+            ->assertPaymentRequired();
+    }
+
+    /** @test */
     public function testOnlyThreadCreatorCanAttachPollToThread()
     {
         $this->attachPollToThread()

--- a/tests/Feature/DeleteCourseTest.php
+++ b/tests/Feature/DeleteCourseTest.php
@@ -13,12 +13,14 @@ class DeleteCourseTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling();
+        $this->withExceptionHandling()->signInUnsubscribed();
     }
 
     /** @test */
     public function testGuestCannotDeleteCourse()
     {
+        Auth::logout();
+
         $this->deleteCourse(1)
             ->assertUnauthorized();
     }
@@ -27,8 +29,6 @@ class DeleteCourseTest extends TestCase
     public function testOnlyAuthorizedUserCanDeleteCourse()
     {
         $course = Course::factory()->create();
-
-        $this->signIn();
 
         $this->deleteCourse($course->id)
             ->assertForbidden();
@@ -42,8 +42,6 @@ class DeleteCourseTest extends TestCase
     /** @test */
     public function testCourseMustExist()
     {
-        $this->signIn();
-
         $this->deleteCourse(999)
             ->assertNotFound();
     }
@@ -51,8 +49,6 @@ class DeleteCourseTest extends TestCase
     /** @test */
     public function testCourseOwnerCanDeleteIt()
     {
-        $this->signIn();
-
         $course = Course::factory()->create(['user_id' => Auth::id()]);
 
         $this->assertDatabaseHas('courses', ['id' => $course->id]);

--- a/tests/Feature/DeleteOccupationTest.php
+++ b/tests/Feature/DeleteOccupationTest.php
@@ -13,12 +13,14 @@ class DeleteOccupationTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling();
+        $this->withExceptionHandling()->signInUnsubscribed();
     }
 
     /** @test */
     public function testGuestCannotDeleteOccupation()
     {
+        Auth::logout();
+
         $this->deleteOccupation(1)
             ->assertUnauthorized();
     }
@@ -27,8 +29,6 @@ class DeleteOccupationTest extends TestCase
     public function testOnlyAuthorizedUserCanDeleteOccupation()
     {
         $occupation = Occupation::factory()->create();
-
-        $this->signIn();
 
         $this->deleteOccupation($occupation->id)
             ->assertForbidden();
@@ -42,8 +42,6 @@ class DeleteOccupationTest extends TestCase
     /** @test */
     public function testOccupationMustExist()
     {
-        $this->signIn();
-
         $this->deleteOccupation(999)
             ->assertNotFound();
     }
@@ -51,8 +49,6 @@ class DeleteOccupationTest extends TestCase
     /** @test */
     public function testOccupationOwnerCanDeleteIt()
     {
-        $this->signIn();
-
         $occupation = Occupation::factory()->create(['user_id' => Auth::id()]);
 
         $this->assertDatabaseHas('occupations', ['id' => $occupation->id]);

--- a/tests/Feature/EditCompanyTest.php
+++ b/tests/Feature/EditCompanyTest.php
@@ -32,6 +32,26 @@ class EditCompanyTest extends TestCase
     }
 
     /** @test */
+    public function testUnsubscribedUserCanUpdateCompany()
+    {
+        $this->signInUnsubscribed();
+
+        $this->updateCompany()
+            ->assertOk();
+    }
+
+    /** @test */
+    public function testSubscribedUserCanUpdateCompany()
+    {
+        $data = Company::factory()->raw();
+
+        $this->updateCompany($data)
+            ->assertJsonMissingValidationErrors()
+            ->assertOk()
+            ->assertJson($data);
+    }
+
+    /** @test */
     public function testNameIsRequiredIfSet()
     {
         $this->updateCompany(['name' => null])
@@ -169,17 +189,6 @@ class EditCompanyTest extends TestCase
     {
         $this->updateCompany(['remarks' => str_repeat('*', 65536)])
             ->assertJsonValidationErrors('remarks');
-    }
-
-    /** @test */
-    public function testCanUpdateCompany()
-    {
-        $data = Company::factory()->raw();
-
-        $this->updateCompany($data)
-            ->assertJsonMissingValidationErrors()
-            ->assertOk()
-            ->assertJson($data);
     }
 
     /**

--- a/tests/Feature/EditCourseTest.php
+++ b/tests/Feature/EditCourseTest.php
@@ -17,7 +17,7 @@ class EditCourseTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling()->signIn();
+        $this->withExceptionHandling()->signInUnsubscribed();
 
         $this->course = Course::factory()->create(['user_id' => Auth::id()]);
     }
@@ -41,6 +41,35 @@ class EditCourseTest extends TestCase
 
         $this->updateCourse()
             ->assertForbidden();
+    }
+
+    /** @test */
+    public function testUserCanUpdateCourse()
+    {
+        $data = [
+            'title' => "Diplôme d'Élève Pilote de Ligne",
+            'school' => 'ENAC',
+            'description' => 'Best flight training in the world. Hands down.',
+            'start_date' => '2015-09-28',
+            'end_date' => '2018-06-13',
+            'location' => [
+                'type' => 'address',
+                'name' => '7 Avenue Edouard Belin, Toulouse, Occitanie, France',
+                'street_line_1' => '7 Avenue Edouard Belin',
+                'street_line_2' => null,
+                'municipality' => 'Toulouse',
+                'administrative_area' => 'Occitanie',
+                'sub_administrative_area' => 'Haute-Garonne',
+                'postal_code' => '31400',
+                'country' => 'France',
+                'country_code' => 'FR',
+            ],
+        ];
+
+        $this->updateCourse($data)
+            ->assertJsonMissingValidationErrors()
+            ->assertOk()
+            ->assertJson($data);
     }
 
     /** @test */
@@ -212,35 +241,6 @@ class EditCourseTest extends TestCase
     {
         $this->updateCourse(['description' => str_repeat('*', 65536)])
             ->assertJsonValidationErrors('description');
-    }
-
-    /** @test */
-    public function testCanUpdateCourse()
-    {
-        $data = [
-            'title' => "Diplôme d'Élève Pilote de Ligne",
-            'school' => 'ENAC',
-            'description' => 'Best flight training in the world. Hands down.',
-            'start_date' => '2015-09-28',
-            'end_date' => '2018-06-13',
-            'location' => [
-                'type' => 'address',
-                'name' => '7 Avenue Edouard Belin, Toulouse, Occitanie, France',
-                'street_line_1' => '7 Avenue Edouard Belin',
-                'street_line_2' => null,
-                'municipality' => 'Toulouse',
-                'administrative_area' => 'Occitanie',
-                'sub_administrative_area' => 'Haute-Garonne',
-                'postal_code' => '31400',
-                'country' => 'France',
-                'country_code' => 'FR',
-            ],
-        ];
-
-        $this->updateCourse($data)
-            ->assertJsonMissingValidationErrors()
-            ->assertOk()
-            ->assertJson($data);
     }
 
     /**

--- a/tests/Feature/EditOccupationTest.php
+++ b/tests/Feature/EditOccupationTest.php
@@ -18,7 +18,7 @@ class EditOccupationTest extends TestCase
     {
         parent::setUp();
 
-        $this->withExceptionHandling()->signIn();
+        $this->withExceptionHandling()->signInUnsubscribed();
 
         $this->occupation = Occupation::factory()->create(['user_id' => Auth::id()]);
     }
@@ -33,12 +33,47 @@ class EditOccupationTest extends TestCase
     }
 
     /** @test */
+    public function testUserCanUpdateOccupation()
+    {
+        $data = [
+            'position' => 'FO',
+            'aircraft_id' => 32, // DHC8 Q400
+            'company' => [
+                'name' => 'Flybe',
+                'description' => 'Cool description',
+            ],
+            'status_code' => 1,
+            'description' => 'Awesome description, even though the company went bust.',
+            'start_date' => '2019-08-01',
+            'end_date' => '2020-03-05',
+            'is_primary' => false,
+            'location' => [
+                'type' => 'city',
+                'name' => 'Belfast, Royaume-Uni',
+                'street_line_1' => null,
+                'street_line_2' => null,
+                'municipality' => 'Belfast',
+                'administrative_area' => 'Northern Ireland',
+                'sub_administrative_area' => 'Royaume-Uni',
+                'postal_code' => 'BT1',
+                'country' => 'Royaume-Uni',
+                'country_code' => 'GB',
+            ],
+        ];
+
+        $this->updateOccupation($data)
+            ->assertJsonMissingValidationErrors()
+            ->assertOk()
+            ->assertJson($data);
+    }
+
+    /** @test */
     public function testOnlyAuthorizedUserCanUpdateOccupation()
     {
         $this->updateOccupation()
             ->assertOk();
 
-        $this->signIn(); // Other user
+        $this->signInUnsubscribed(); // Other user
 
         $this->updateOccupation()
             ->assertForbidden();
@@ -363,41 +398,6 @@ class EditOccupationTest extends TestCase
             ->assertJson(['company' => $company->toArray()]);
 
         $this->assertDatabaseCount('companies', 2);
-    }
-
-    /** @test */
-    public function testCanUpdateOccupation()
-    {
-        $data = [
-            'position' => 'FO',
-            'aircraft_id' => 32, // DHC8 Q400
-            'company' => [
-                'name' => 'Flybe',
-                'description' => 'Cool description',
-            ],
-            'status_code' => 1,
-            'description' => 'Awesome description, even though the company went bust.',
-            'start_date' => '2019-08-01',
-            'end_date' => '2020-03-05',
-            'is_primary' => false,
-            'location' => [
-                'type' => 'city',
-                'name' => 'Belfast, Royaume-Uni',
-                'street_line_1' => null,
-                'street_line_2' => null,
-                'municipality' => 'Belfast',
-                'administrative_area' => 'Northern Ireland',
-                'sub_administrative_area' => 'Royaume-Uni',
-                'postal_code' => 'BT1',
-                'country' => 'Royaume-Uni',
-                'country_code' => 'GB',
-            ],
-        ];
-
-        $this->updateOccupation($data)
-            ->assertJsonMissingValidationErrors()
-            ->assertOk()
-            ->assertJson($data);
     }
 
     /**

--- a/tests/Feature/EditPollTest.php
+++ b/tests/Feature/EditPollTest.php
@@ -30,6 +30,15 @@ class EditPollTest extends TestCase
     }
 
     /** @test */
+    public function testUnsubscribedUsersCannotEditPoll()
+    {
+        $this->signInUnsubscribed();
+
+        $this->updatePoll()
+            ->assertPaymentRequired();
+    }
+
+    /** @test */
     public function testOnlyPollThreadCreatorCanEditPoll()
     {
         $this->updatePoll()
@@ -262,6 +271,15 @@ class EditPollTest extends TestCase
 
         $this->deletePoll()
             ->assertUnauthorized();
+    }
+
+    /** @test */
+    public function testUnsubscribedUsersCannotDeletePoll()
+    {
+        $this->signInUnsubscribed();
+
+        $this->deletePoll()
+            ->assertPaymentRequired();
     }
 
     /** @test */

--- a/tests/Feature/ReadPagesTest.php
+++ b/tests/Feature/ReadPagesTest.php
@@ -22,6 +22,15 @@ class ReadPagesTest extends TestCase
     }
 
     /** @test */
+    public function testUnsubscribedUsersCanViewUnrestrictedPages()
+    {
+        $this->signInUnsubscribed();
+
+        $this->get(route('pages.show', Page::factory()->create(['restricted' => false])))
+            ->assertOk();
+    }
+
+    /** @test */
     public function testGuestsCannotViewRestrictedPages()
     {
         $this->get(route('pages.show', Page::factory()->create(['restricted' => true])))
@@ -29,7 +38,16 @@ class ReadPagesTest extends TestCase
     }
 
     /** @test */
-    public function testUsersCanViewRestrictedPages()
+    public function testUnsubscribedUsersCannotViewRestrictedPages()
+    {
+        $this->signInUnsubscribed();
+
+        $this->get(route('pages.show', Page::factory()->create(['restricted' => true])))
+            ->assertRedirect(route('subscription.edit'));
+    }
+
+    /** @test */
+    public function testSubscribedUsersCanViewRestrictedPages()
     {
         $this->signIn();
 

--- a/tests/Feature/ReadThreadsTest.php
+++ b/tests/Feature/ReadThreadsTest.php
@@ -22,7 +22,7 @@ class ReadThreadsTest extends TestCase
     }
 
     /** @test */
-    public function testGuestCannotIndexThreads()
+    public function testGuestsCannotIndexThreads()
     {
         Auth::logout();
 
@@ -31,14 +31,41 @@ class ReadThreadsTest extends TestCase
     }
 
     /** @test */
-    public function testUserCanIndexThreads()
+    public function testUnsubscribedUsersCannotIndexThreads()
+    {
+        $this->signInUnsubscribed();
+
+        $this->get(route('threads.index'))
+            ->assertRedirect(route('subscription.edit'));
+    }
+
+    /** @test */
+    public function testSubscribedUsersCanIndexThreads()
     {
         $this->get(route('threads.index'))
             ->assertSee($this->thread->title);
     }
 
     /** @test */
-    public function testUserCanViewASingleThread()
+    public function testGuestsCannotViewAThread()
+    {
+        Auth::logout();
+
+        $this->get($this->thread->path())
+            ->assertRedirect(route('login'));
+    }
+
+    /** @test */
+    public function testUnsubscribedUsersCannotViewAThread()
+    {
+        $this->signInUnsubscribed();
+
+        $this->get($this->thread->path())
+            ->assertRedirect(route('subscription.edit'));
+    }
+
+    /** @test */
+    public function testUserCanViewAThread()
     {
         $this->get($this->thread->path())
             ->assertSee($this->thread->title);

--- a/tests/Feature/RestrictedChannelsTest.php
+++ b/tests/Feature/RestrictedChannelsTest.php
@@ -20,7 +20,7 @@ class RestrictedChannelsTest extends TestCase
     {
         parent::setUp();
 
-        $this->signIn()->withExceptionHandling();
+        $this->withExceptionHandling()->signIn();
 
         $this->channel = Channel::factory()->create(['name' => 'Foobar Channel']);
     }

--- a/tests/Feature/SubscriptionTest.php
+++ b/tests/Feature/SubscriptionTest.php
@@ -26,6 +26,30 @@ class SubscriptionTest extends StripeTestCase
      * @group external-api
      * @group stripe-api
      */
+    public function testBillingPageShowsAlertIfUnsubscribed()
+    {
+        $this->get(route('subscription.edit'))
+            ->assertSee('Ta cotisation n’est pas à jour.');
+    }
+
+    /**
+     * @test
+     * @group external-api
+     * @group stripe-api
+     */
+    public function testBillingPageDoesntShowAlertIfSubscribed()
+    {
+        Auth::user()->newSubscription('default', config('council.plans.agepac'))->add();
+
+        $this->get(route('subscription.edit'))
+            ->assertDontSee('Ta cotisation n’est pas à jour.');
+    }
+
+    /**
+     * @test
+     * @group external-api
+     * @group stripe-api
+     */
     public function testAUserMustHaveADefaultPaymentMethodToSubscribe()
     {
         $this->signInUnsubscribed();

--- a/tests/Feature/SubscriptionTest.php
+++ b/tests/Feature/SubscriptionTest.php
@@ -28,7 +28,7 @@ class SubscriptionTest extends StripeTestCase
      */
     public function testAUserMustHaveADefaultPaymentMethodToSubscribe()
     {
-        $this->signIn();
+        $this->signInUnsubscribed();
 
         $this->createSubscription()->assertForbidden();
 

--- a/tests/Feature/ViewDashboardTest.php
+++ b/tests/Feature/ViewDashboardTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class ViewDashboardTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withExceptionHandling();
+    }
+
+    /** @test */
+    public function testGuestsCannotSeeDashboard()
+    {
+        $this->getDashboard()
+            ->assertRedirect(route('login'));
+    }
+
+    /** @test */
+    public function testUsersCanSeeDashboard()
+    {
+        $this->signIn();
+
+        $this->getDashboard()
+            ->assertSuccessful()
+            ->assertViewIs('home');
+    }
+
+    protected function getDashboard()
+    {
+        return $this->get(route('home'));
+    }
+}

--- a/tests/Feature/ViewDashboardTest.php
+++ b/tests/Feature/ViewDashboardTest.php
@@ -21,7 +21,16 @@ class ViewDashboardTest extends TestCase
     }
 
     /** @test */
-    public function testUsersCanSeeDashboard()
+    public function testUnsubscribedUsersCannotSeeDashboard()
+    {
+        $this->signInUnsubscribed();
+
+        $this->getDashboard()
+            ->assertRedirect(route('subscription.edit'));
+    }
+
+    /** @test */
+    public function testSubscribedUsersCanSeeDashboard()
     {
         $this->signIn();
 

--- a/tests/Feature/ViewPollResultsTest.php
+++ b/tests/Feature/ViewPollResultsTest.php
@@ -28,7 +28,16 @@ class ViewPollResultsTest extends TestCase
     }
 
     /** @test */
-    public function testIfAllowedUsersCanViewResultsBeforeVoting()
+    public function testUnsubscribedUsersCannotViewPollResults()
+    {
+        $this->signInUnsubscribed();
+
+        $this->getPollResults()
+            ->assertPaymentRequired();
+    }
+
+    /** @test */
+    public function testIfAllowedSubscribedUsersCanViewResultsBeforeVoting()
     {
         $this->signIn();
 
@@ -43,7 +52,7 @@ class ViewPollResultsTest extends TestCase
     }
 
     /** @test */
-    public function testIfNotAllowedUsersCannotViewResultsBeforeVoting()
+    public function testIfNotAllowedSubscribedUsersCannotViewResultsBeforeVoting()
     {
         $this->signIn();
 
@@ -71,7 +80,7 @@ class ViewPollResultsTest extends TestCase
     }
 
     /** @test */
-    public function testPollUsersWithPermissionsCanViewResultsWithoutVoting()
+    public function testUsersWithPermissionsCanViewResultsWithoutVoting()
     {
         $this->signInWithPermission('threads.edit');
 
@@ -82,7 +91,7 @@ class ViewPollResultsTest extends TestCase
     }
 
     /** @test */
-    public function testIfVotesArePublicUsersCanViewVotes()
+    public function testIfVotesArePublicSubscribedUsersCanViewVotes()
     {
         $this->signIn();
 
@@ -92,7 +101,7 @@ class ViewPollResultsTest extends TestCase
     }
 
     /** @test */
-    public function testIfVotesArePrivateUsersCannotViewVotes()
+    public function testIfVotesArePrivateSubscribedUsersCannotViewVotes()
     {
         $this->signIn();
 

--- a/tests/Feature/ViewProfileTest.php
+++ b/tests/Feature/ViewProfileTest.php
@@ -33,9 +33,28 @@ class ViewProfileTest extends TestCase
     }
 
     /** @test */
-    public function testUserHasAProfile()
+    public function testUnsubscribedUsersCannotSeeProfiles()
+    {
+        $this->signInUnsubscribed();
+
+        $this->getProfile()
+            ->assertRedirect(route('subscription.edit'));
+    }
+
+    /** @test */
+    public function testUnsubscribedUserCanSeeOwnProfile()
+    {
+        $this->signInUnsubscribed();
+
+        $this->getProfile(Auth::user())
+            ->assertOk();
+    }
+
+    /** @test */
+    public function testSubscribedUserCanSeeProfiles()
     {
         $this->getProfile()
+            ->assertOk()
             ->assertSee($this->profile->name);
     }
 

--- a/tests/Feature/VoteInPollTest.php
+++ b/tests/Feature/VoteInPollTest.php
@@ -31,7 +31,16 @@ class VoteInPollTest extends TestCase
     }
 
     /** @test */
-    public function testUsersCanViewPoll()
+    public function testUnsubscribedUsersCannotViewPoll()
+    {
+        $this->signInUnsubscribed();
+
+        $this->getPoll()
+            ->assertPaymentRequired();
+    }
+
+    /** @test */
+    public function testSubscribedUsersCanViewPoll()
     {
         $this->getPoll()
             ->assertOk()
@@ -62,7 +71,16 @@ class VoteInPollTest extends TestCase
     }
 
     /** @test */
-    public function testUsersWithAccessToTheThreadCanVote()
+    public function testUnsubscribedUsersCannotVote()
+    {
+        $this->signInUnsubscribed();
+
+        $this->voteInPoll()
+            ->assertPaymentRequired();
+    }
+
+    /** @test */
+    public function testSubscribedUsersCanVote()
     {
         $this->voteInPoll()
             ->assertOk();

--- a/tests/StripeTestCase.php
+++ b/tests/StripeTestCase.php
@@ -29,7 +29,7 @@ abstract class StripeTestCase extends TestCase
         bool $withDefaultPaymentMethod = false,
         string $paymentMethodId = 'pm_card_visa'
     ) {
-        $user = tap(User::factory()->create($overrides))->createAsStripeCustomer();
+        $user = tap(User::factory()->withoutSubscription()->create($overrides))->createAsStripeCustomer();
 
         $user->{$withDefaultPaymentMethod ? 'updateDefaultPaymentMethod' : 'addPaymentMethod'}($paymentMethodId);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,18 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
+     * Sign in with a user without a subscription.
+     *
+     * @return $this
+     */
+    protected function signInUnsubscribed()
+    {
+        return $this->signIn(
+            User::factory()->withoutSubscription()->create()
+        );
+    }
+
+    /**
      * Sign in with a user and give it a permission.
      *
      * @param  string|string[]  $permission

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -13,6 +13,17 @@ use Tests\TestCase;
 class ActivityTest extends TestCase
 {
     /** @test */
+    public function testDoesntRecordActivityIfNoAuthenticatedUser()
+    {
+        $post = Post::factory()->create();
+
+        $this->assertDatabaseMissing('activities', [
+            'subject_id' => $post->id,
+            'subject_type' => array_flip(Relation::$morphMap)[get_class($post)],
+        ]);
+    }
+
+    /** @test */
     public function testRecordsActivityWhenUserIsCreated()
     {
         $user = User::factory()->create();

--- a/tests/Unit/UnsubscribedExceptionTest.php
+++ b/tests/Unit/UnsubscribedExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Exceptions\UnsubscribedException;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class UnsubscribedExceptionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withExceptionHandling();
+
+        Route::any('exception-test', function () {
+            throw new UnsubscribedException;
+        });
+    }
+
+    /** @test */
+    public function testExceptionHandlerRedirectsToBillingPage()
+    {
+        $this->get('exception-test')
+            ->assertRedirect(route('subscription.edit'));
+    }
+
+    /** @test */
+    public function testExceptionHandlerReturns402StatusForJsonRequest()
+    {
+        $this->getJson('exception-test')
+            ->assertPaymentRequired();
+    }
+}


### PR DESCRIPTION
Limit access of unsubscribed users to specific pages and redirect them to the subscription page if they attempt to access an off-limits page.