### PR TITLE
Deactivate Mailcoach Cloud syncing

### DIFF
--- a/app/Observers/SubscriptionObserver.php
+++ b/app/Observers/SubscriptionObserver.php
@@ -16,13 +16,13 @@ class SubscriptionObserver
      */
     public function saved(StripeSubscription $subscription)
     {
-        if ($subscription->valid() || $this->hasActiveSubscription($subscription->user)) {
-            app(SubscribeUserToMembersNewsletterAction::class)->execute($subscription->user);
-
-            return;
-        }
-
-        app(UnsubscribeUserFromMembersNewsletterAction::class)->execute($subscription->user);
+        // if ($subscription->valid() || $this->hasActiveSubscription($subscription->user)) {
+        //     app(SubscribeUserToMembersNewsletterAction::class)->execute($subscription->user);
+        //
+        //     return;
+        // }
+        //
+        // app(UnsubscribeUserFromMembersNewsletterAction::class)->execute($subscription->user);
     }
 
     /**
@@ -32,13 +32,13 @@ class SubscriptionObserver
      */
     public function deleted(StripeSubscription $subscription)
     {
-        if ($this->hasActiveSubscription($subscription->user)) {
-            app(SubscribeUserToMembersNewsletterAction::class)->execute($subscription->user);
-
-            return;
-        }
-
-        app(UnsubscribeUserFromMembersNewsletterAction::class)->execute($subscription->user);
+        // if ($this->hasActiveSubscription($subscription->user)) {
+        //     app(SubscribeUserToMembersNewsletterAction::class)->execute($subscription->user);
+        //
+        //     return;
+        // }
+        //
+        // app(UnsubscribeUserFromMembersNewsletterAction::class)->execute($subscription->user);
     }
 
     protected function hasActiveSubscription(User $user)

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -13,20 +13,20 @@ class UserObserver
 {
     public function created(User $user)
     {
-        app(SubscribeUserToNewsletterAction::class)->execute($user);
+        // app(SubscribeUserToNewsletterAction::class)->execute($user);
 
         LegacySync::syncRecord($user->getTable(), $user->getKey(), SyncDirection::LegacyToNew);
     }
 
     public function updated(User $user)
     {
-        if ($user->wasChanged('email')) {
-            app(UpdateUserNewsletterEmailAction::class)->execute($user);
-        }
+        // if ($user->wasChanged('email')) {
+        //     app(UpdateUserNewsletterEmailAction::class)->execute($user);
+        // }
     }
 
     public function deleted(User $user)
     {
-        app(UnsubscribeUserFromNewsletterAction::class)->execute($user);
+        // app(UnsubscribeUserFromNewsletterAction::class)->execute($user);
     }
 }


### PR DESCRIPTION
This PR deactivates the Mailcoach Cloud syncing logic which was found in the `UserObserver` and `SubscriptionObserver` observers.

The objective of this is to transfer this responsibility to the newer AGEPAC app. See PR clarkewing/agepac.org-new#15