### PR TITLE
Force every user through a password reset on next login

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -49,7 +49,30 @@ class LoginController extends Controller
             $this->username() => 'required|string',
         ]);
 
-        return $this->handleUnmigratedUser() ?: $this->traitLogin($request);
+        return $this->handleUnmigratedUser()
+            ?: $this->handleResetRequiredUser($request)
+            ?: $this->traitLogin($request);
+    }
+
+    /**
+     * Catch users whose password was force-invalidated after the security
+     * incident. Hand them off to the ForcedPasswordReset Livewire flow so
+     * they can verify by email token and set a new password without leaving
+     * the site.
+     *
+     * @return \Illuminate\Contracts\View\View|bool
+     */
+    protected function handleResetRequiredUser(Request $request)
+    {
+        $user = User::where($this->username(), $request->input($this->username()))
+            ->where('password', User::PASSWORD_RESET_SENTINEL)
+            ->first();
+
+        if (is_null($user)) {
+            return false;
+        }
+
+        return view('auth.reset-required', ['user' => $user]);
     }
 
     /**
@@ -71,7 +94,7 @@ class LoginController extends Controller
      */
     protected function handleUnmigratedUser()
     {
-        $unmigratedUser = User::where($this->username(), request()->input($this->username()))
+         $unmigratedUser = User::where($this->username(), request()->input($this->username()))
             ->whereNull('password')
             ->first();
 

--- a/app/Http/Livewire/ForcedPasswordReset.php
+++ b/app/Http/Livewire/ForcedPasswordReset.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use App\Models\User;
+use App\Notifications\VerificationToken;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+use Livewire\Component;
+
+class ForcedPasswordReset extends Component
+{
+    /**
+     * Public Livewire properties are hydrated from the client payload on
+     * every request, so they can be tampered with — never trust $verified
+     * or $resent as authorization state.
+     * The authoritative verified flag lives in the session under
+     * SESSION_KEY and is re-checked on every server action.
+     * $user is safe because Livewire 2 refuses to rebind Eloquent properties
+     * without an explicit validation rule.
+     */
+    public User $user;
+
+    public $token;
+
+    public $verified = false;
+
+    public $resent = false;
+
+    public $password;
+
+    public $password_confirmation;
+
+    protected const SESSION_KEY = 'forcedPasswordReset';
+
+    protected function rules()
+    {
+        return [
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+
+    public function mount(User $user)
+    {
+        $this->user = $user;
+
+        Session::put(self::SESSION_KEY, [
+            'token' => null,
+            'verified' => false,
+        ]);
+
+        $this->sendToken();
+    }
+
+    public function verify()
+    {
+        $this->validate([
+            'token' => ['required', 'string', 'digits:6', Rule::in([$this->expectedToken()])],
+        ]);
+
+        Session::put(self::SESSION_KEY . '.verified', true);
+
+        $this->verified = true;
+    }
+
+    public function resetPassword()
+    {
+        abort_unless(Session::get(self::SESSION_KEY . '.verified') === true, 403);
+
+        $this->validate();
+
+        $this->user->forceFill([
+            'password' => Hash::make($this->password),
+            'remember_token' => null,
+        ])->save();
+
+        Session::forget(self::SESSION_KEY);
+
+        Auth::login($this->user);
+
+        $this->redirect(route('home'));
+    }
+
+    public function sendToken(): void
+    {
+        $token = sprintf('%06d', mt_rand(0, 999999));
+
+        Session::put(self::SESSION_KEY . '.token', $token);
+
+        $this->user->notify(new VerificationToken($token));
+    }
+
+    public function resendToken(): void
+    {
+        if ($this->resent) {
+            return;
+        }
+
+        $this->user->notify(new VerificationToken($this->expectedToken()));
+
+        $this->resent = true;
+    }
+
+    protected function expectedToken(): ?string
+    {
+        return Session::get(self::SESSION_KEY . '.token');
+    }
+}

--- a/app/Http/Livewire/ForcedPasswordReset.php
+++ b/app/Http/Livewire/ForcedPasswordReset.php
@@ -66,6 +66,16 @@ class ForcedPasswordReset extends Component
         $this->verified = true;
     }
 
+    /**
+     * Snap the public $verified property back to the session-backed truth
+     * on every client update, so a malicious client cannot flip it to true
+     * to skip the email-token step or advance the view to step 2.
+     */
+    public function updatedVerified()
+    {
+        $this->verified = Session::get(self::SESSION_KEY . '.verified', false) === true;
+    }
+
     public function resetPassword()
     {
         abort_unless(Session::get(self::SESSION_KEY . '.verified') === true, 403);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,14 @@ use URLify;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
+    /**
+     * Sentinel written to users.password to force a reset on next login.
+     * Not a valid bcrypt hash, so Hash::check() always fails against it.
+     * See LoginController::handleResetRequiredUser() and the 2026_05_31
+     * invalidate_all_passwords migration.
+     */
+    public const PASSWORD_RESET_SENTINEL = 'RESET_REQUIRED';
+
     use HasFactory;
     use HasReputation;
     use HasRoles;

--- a/database/migrations/2026_05_31_000000_invalidate_all_passwords.php
+++ b/database/migrations/2026_05_31_000000_invalidate_all_passwords.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class InvalidateAllPasswords extends Migration
+{
+    /**
+     * Post-incident remediation: invalidate every active user's password so
+     * they are forced through the email-based reset flow on next login.
+     */
+    public function up(): void
+    {
+        DB::table('users')
+            ->whereNotNull('password')
+            ->where('password', '!=', User::PASSWORD_RESET_SENTINEL)
+            ->update([
+                'password' => User::PASSWORD_RESET_SENTINEL,
+                'remember_token' => null,
+            ]);
+
+        if (Schema::hasTable('password_resets')) {
+            DB::table('password_resets')->truncate();
+        }
+
+        if (Schema::hasTable('sessions')) {
+            DB::table('sessions')->truncate();
+        }
+    }
+
+    public function down(): void
+    {
+        // No-op: invalidated passwords cannot be restored. Roll back by
+        // restoring from a pre-incident database backup.
+    }
+}

--- a/resources/views/auth/reset-required.blade.php
+++ b/resources/views/auth/reset-required.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.form-with-bg')
+
+@push('styles')
+    @livewireStyles
+@endpush
+
+@push('scripts')
+    @livewireScripts
+@endpush
+
+@section('card-body')
+    <livewire:forced-password-reset :user="$user" />
+@endsection

--- a/resources/views/livewire/forced-password-reset.blade.php
+++ b/resources/views/livewire/forced-password-reset.blade.php
@@ -1,0 +1,126 @@
+<div>
+    <h2 class="card-title text-center">Sécurisation du compte</h2>
+
+    <div class="p-3">
+        @if(! $verified)
+            <div class="alert alert-warning" role="alert">
+                <h4 class="alert-heading">Incident de sécurité</h4>
+                <p>
+                    Notre site a récemment été la cible d’une cyberattaque. Par précaution, nous avons invalidé
+                    l’ensemble des mots de passe des membres — y compris le tien — et tu dois en définir un nouveau pour
+                    te reconnecter.
+                </p>
+                <hr>
+                <p class="mb-0">
+                    Si tu as des questions, n’hésite pas à <a href="mailto:bureau@agepac.org" class="alert-link">nous contacter</a>.
+                </p>
+            </div>
+
+            <p class="text-center text-muted mb-4">
+                Afin de confirmer ton identité, nous t’avons envoyé un email contenant un code à usage unique.
+            </p>
+
+            <form wire:submit.prevent="verify">
+                <div class="form-group text-center">
+                    <label for="token">
+                        Saisis le code à 6 chiffres
+                    </label>
+
+                    <input type="text"
+                           class="form-control text-center w-50 mx-auto @error('token') is-invalid @enderror"
+                           id="token"
+                           wire:model.defer="token"
+                           inputmode="numeric"
+                           autocomplete="one-time-code"
+                           required
+                           pattern="[0-9]*"
+                           autofocus>
+
+                    <small class="form-text text-muted" id="otpHelp">
+                        @if($resent)
+                            Le code a été renvoyé à ton adresse email.
+                        @else
+                            Tu n’as pas reçu de code ?
+                            <a href="#" wire:click.prevent="resendToken" class="text-muted">
+                                Le renvoyer
+                            </a>
+                        @endif
+                    </small>
+
+                    @error('token')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <button type="submit" class="btn btn-primary rounded-pill d-flex align-items-center mx-auto">
+                    <span>Vérifier</span>
+
+                    <svg class="bi bi-arrow-right-short ml-2" width="1em" height="1em" viewBox="0 0 16 16"
+                         fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd"
+                              d="M8.146 4.646a.5.5 0 01.708 0l3 3a.5.5 0 010 .708l-3 3a.5.5 0 01-.708-.708L10.793 8 8.146 5.354a.5.5 0 010-.708z"
+                              clip-rule="evenodd"/>
+                        <path fill-rule="evenodd" d="M4 8a.5.5 0 01.5-.5H11a.5.5 0 010 1H4.5A.5.5 0 014 8z"
+                              clip-rule="evenodd"/>
+                    </svg>
+                </button>
+            </form>
+        @else
+            <p class="text-center text-muted mb-4">
+                Choisis un nouveau mot de passe pour ton compte AGEPAC.
+            </p>
+
+            <form wire:submit.prevent="resetPassword">
+                <div class="form-group">
+                    <label for="password">
+                        Nouveau mot de passe
+                    </label>
+
+                    <input type="password"
+                           class="form-control @error('password') is-invalid @enderror"
+                           id="password"
+                           wire:model.defer="password"
+                           autocomplete="new-password"
+                           placeholder="Foy=Maison<3"
+                           required
+                           autofocus>
+
+                    <small class="form-text text-muted" id="passwordHelp">
+                        Choisis quelque chose de sûr et d’au moins 8 caractères.
+                    </small>
+
+                    @error('password')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="form-group mb-4">
+                    <label for="password_confirmation">
+                        Confirmation
+                    </label>
+
+                    <input type="password"
+                           class="form-control @error('password_confirmation') is-invalid @enderror"
+                           id="password_confirmation"
+                           wire:model.defer="password_confirmation"
+                           autocomplete="new-password"
+                           required>
+
+                    @error('password_confirmation')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <button type="submit" class="btn btn-primary rounded-pill d-flex align-items-center mx-auto">
+                    <span>Valider</span>
+
+                    <svg class="bi flaticon-takeoff ml-2" width="1em" height="1em" viewBox="0 0 12 12"
+                         fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd"
+                              d="M1.2 8.2c-.1.1-.1.2-.1.3.1.1.2.2.4.2l4-1.3-.8 1.2c-.1.1 0 .2 0 .3.1.1.2.1.3 0l.8-.4h.1L8.2 6l2.9-1.5c1.1-.6 1-1 .9-1.2 0-.1-.2-.2-.4-.3-.3-.1-.6-.1-1 0h-.3c-.3 0-.5 0-1.6.5L3 6.6.8 5.5H.5l-.3.2c-.1 0-.2.1-.2.2s0 .1.1.2L1.6 8l-.4.2z"/>
+                    </svg>
+                </button>
+            </form>
+        @endif
+    </div>
+</div>

--- a/tests/Feature/ForcedPasswordResetTest.php
+++ b/tests/Feature/ForcedPasswordResetTest.php
@@ -245,8 +245,9 @@ class ForcedPasswordResetTest extends TestCase
     {
         // $verified is a public Livewire property, so a malicious client
         // can flip it to true in the request payload without going through
-        // verify(). The server's source of truth must be the session, not
-        // the property — this test pins that.
+        // verify(). The updatedVerified() hook snaps it back to the
+        // session-backed truth, and resetPassword()'s abort_unless is the
+        // final boundary.
         $this->getComponent()
             ->set('verified', true)
             ->set('password', 'NewSecurePassword123!')
@@ -258,6 +259,24 @@ class ForcedPasswordResetTest extends TestCase
 
         $this->assertSame(User::PASSWORD_RESET_SENTINEL, $this->user->password);
         $this->assertFalse(Auth::check());
+    }
+
+    /** @test */
+    public function testTamperingWithVerifiedDoesNotLeakUserFirstName()
+    {
+        // Without the updatedVerified() hook, flipping $verified to true
+        // would advance the view to step 2 which renders "Bonjour
+        // {{ $user->first_name }} !" — leaking the first name to anyone
+        // who knows a sentinel user's email. The hook prevents this by
+        // resetting $verified to the session value on every client update,
+        // keeping the view on step 1.
+        $this->user->update(['first_name' => 'Unguessable']);
+
+        $this->getComponent()
+            ->set('verified', true)
+            ->assertSet('verified', false)
+            ->assertDontSee('Unguessable')
+            ->assertSee('Saisis le code à 6 chiffres');
     }
 
     /** @test */

--- a/tests/Feature/ForcedPasswordResetTest.php
+++ b/tests/Feature/ForcedPasswordResetTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\Auth\LoginController;
+use App\Http\Livewire\ForcedPasswordReset;
+use App\Models\User;
+use App\Notifications\VerificationToken;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Session;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ForcedPasswordResetTest extends TestCase
+{
+    /** @var \App\Models\User */
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withExceptionHandling();
+
+        $this->user = User::factory()->create([
+            'email' => 'jane@example.com',
+            'password' => User::PASSWORD_RESET_SENTINEL,
+        ]);
+    }
+
+    /** @test */
+    public function testHashCheckAlwaysFailsAgainstTheSentinel()
+    {
+        $this->assertFalse(Hash::check('anything', User::PASSWORD_RESET_SENTINEL));
+        $this->assertFalse(Hash::check('', User::PASSWORD_RESET_SENTINEL));
+        $this->assertFalse(Hash::check(User::PASSWORD_RESET_SENTINEL, User::PASSWORD_RESET_SENTINEL));
+    }
+
+    /** @test */
+    public function testInvalidatedUserSeesForcedResetComponentOnLoginAttempt()
+    {
+        $this->post(action([LoginController::class, 'login']), [
+            'email' => $this->user->email,
+            'password' => 'whatever-they-used-to-have',
+        ])
+            ->assertOk()
+            ->assertViewIs('auth.reset-required')
+            ->assertViewHas('user', fn ($u) => $u->is($this->user))
+            ->assertSeeLivewire('forced-password-reset');
+    }
+
+    /** @test */
+    public function testUnknownUserGetsStandardInvalidCredentialsPath()
+    {
+        // No special branch for unknown emails — they hit the normal failure
+        // path, so the incident doesn't leak which accounts exist.
+        Notification::fake();
+
+        $this->post(action([LoginController::class, 'login']), [
+            'email' => 'nobody@example.com',
+            'password' => 'anything',
+        ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('email');
+
+        Notification::assertNothingSent();
+    }
+
+    /** @test */
+    public function testLegacyNullPasswordUserStillHitsMigrateWizard()
+    {
+        $legacyUser = User::factory()->create([
+            'email' => 'legacy@example.com',
+            'password' => null,
+        ]);
+
+        $this->post(action([LoginController::class, 'login']), [
+            'email' => $legacyUser->email,
+        ])
+            ->assertSeeLivewire('migrate');
+    }
+
+    /** @test */
+    public function testMountSendsVerificationTokenToUser()
+    {
+        Notification::fake();
+
+        $this->getComponent();
+
+        Notification::assertSentTo($this->user, VerificationToken::class);
+    }
+
+    /** @test */
+    public function testTokenIsRequired()
+    {
+        $this->getComponent()
+            ->set('token', null)
+            ->call('verify')
+            ->assertHasErrors('token');
+    }
+
+    /** @test */
+    public function testTokenMustBeExactlySixDigits()
+    {
+        $this->getComponent()
+            ->set('token', '123')
+            ->call('verify')
+            ->assertHasErrors('token');
+
+        $this->getComponent()
+            ->set('token', 'abc123')
+            ->call('verify')
+            ->assertHasErrors('token');
+    }
+
+    /** @test */
+    public function testTokenMustMatchExpectedToken()
+    {
+        $component = $this->getComponent();
+
+        do {
+            $incorrectToken = sprintf('%06d', mt_rand(0, 999999));
+        } while ($incorrectToken === $this->getExpectedToken());
+
+        $component
+            ->set('token', $incorrectToken)
+            ->call('verify')
+            ->assertHasErrors('token');
+    }
+
+    /** @test */
+    public function testCorrectTokenAdvancesToPasswordStep()
+    {
+        $this->getComponent()
+            ->set('token', $this->getExpectedToken())
+            ->call('verify')
+            ->assertHasNoErrors()
+            ->assertSet('verified', true);
+    }
+
+    /** @test */
+    public function testCanRequestTokenResendOnce()
+    {
+        Notification::fake();
+
+        $component = $this->getComponent();
+
+        Notification::assertSentToTimes($this->user, VerificationToken::class, 1);
+
+        $component
+            ->call('resendToken')
+            ->assertSet('resent', true);
+
+        Notification::assertSentToTimes($this->user, VerificationToken::class, 2);
+
+        Notification::fake(); // Reset counter
+
+        $component->call('resendToken');
+
+        Notification::assertNothingSent();
+    }
+
+    /** @test */
+    public function testPasswordIsRequiredOnReset()
+    {
+        $this->verifiedComponent()
+            ->set('password', null)
+            ->call('resetPassword')
+            ->assertHasErrors(['password' => 'required']);
+    }
+
+    /** @test */
+    public function testPasswordMustMeetDefaultsPolicy()
+    {
+        // Uses Rules\Password::defaults() — same rule object the standard
+        // ResetPasswordController uses. Currently equivalent to min(8) but
+        // tracks any project-wide policy changes via Password::defaults(...)
+        // in a service provider.
+        $this->verifiedComponent()
+            ->set('password', 'short')
+            ->set('password_confirmation', 'short')
+            ->call('resetPassword')
+            ->assertHasErrors('password');
+    }
+
+    /** @test */
+    public function testPasswordMustBeConfirmed()
+    {
+        $this->verifiedComponent()
+            ->set('password', 'NewSecurePassword123!')
+            ->set('password_confirmation', 'mismatch')
+            ->call('resetPassword')
+            ->assertHasErrors(['password' => 'confirmed']);
+    }
+
+    /** @test */
+    public function testSuccessfulResetReplacesSentinelWithHashedPassword()
+    {
+        $this->verifiedComponent()
+            ->set('password', 'NewSecurePassword123!')
+            ->set('password_confirmation', 'NewSecurePassword123!')
+            ->call('resetPassword');
+
+        $this->user->refresh();
+
+        $this->assertNotSame(User::PASSWORD_RESET_SENTINEL, $this->user->password);
+        $this->assertTrue(Hash::check('NewSecurePassword123!', $this->user->password));
+    }
+
+    /** @test */
+    public function testSuccessfulResetLogsTheUserInAndRedirectsHome()
+    {
+        $this->verifiedComponent()
+            ->set('password', 'NewSecurePassword123!')
+            ->set('password_confirmation', 'NewSecurePassword123!')
+            ->call('resetPassword')
+            ->assertRedirect(route('home'));
+
+        $this->assertTrue(Auth::check());
+        $this->assertTrue(Auth::user()->is($this->user));
+    }
+
+    /** @test */
+    public function testCannotResetPasswordWithoutVerifyingFirst()
+    {
+        // Server-side guard: even though the UI hides the password form
+        // until verified, a Livewire client could call resetPassword
+        // directly. The component must reject it.
+        $this->getComponent()
+            ->set('password', 'NewSecurePassword123!')
+            ->set('password_confirmation', 'NewSecurePassword123!')
+            ->call('resetPassword')
+            ->assertForbidden();
+
+        $this->user->refresh();
+
+        $this->assertSame(User::PASSWORD_RESET_SENTINEL, $this->user->password);
+        $this->assertFalse(Auth::check());
+    }
+
+    /** @test */
+    public function testCannotBypassVerificationByTamperingWithVerifiedProperty()
+    {
+        // $verified is a public Livewire property, so a malicious client
+        // can flip it to true in the request payload without going through
+        // verify(). The server's source of truth must be the session, not
+        // the property — this test pins that.
+        $this->getComponent()
+            ->set('verified', true)
+            ->set('password', 'NewSecurePassword123!')
+            ->set('password_confirmation', 'NewSecurePassword123!')
+            ->call('resetPassword')
+            ->assertForbidden();
+
+        $this->user->refresh();
+
+        $this->assertSame(User::PASSWORD_RESET_SENTINEL, $this->user->password);
+        $this->assertFalse(Auth::check());
+    }
+
+    /** @test */
+    public function testLivewireBlocksRebindingTheUserProperty()
+    {
+        // Both users are sentinel users (true for everyone post-incident),
+        // so an attacker who controls account A might try to swap $user to
+        // account B between mount and resetPassword to ride A's verified
+        // token. Livewire 2 blocks this at the framework level — it refuses
+        // to rebind Eloquent model properties without an explicit rule,
+        // throwing CannotBindToModelDataWithoutValidationRuleException.
+        // Our authorizedUser() guard is defense-in-depth in case someone
+        // later adds a rule for $user.
+        $victim = User::factory()->create([
+            'email' => 'victim@example.com',
+            'password' => User::PASSWORD_RESET_SENTINEL,
+        ]);
+
+        $this->expectException(\Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException::class);
+
+        $this->getComponent()->set('user', $victim);
+    }
+
+    /**
+     * @return \Livewire\Testing\TestableLivewire
+     */
+    protected function getComponent(): \Livewire\Testing\TestableLivewire
+    {
+        return Livewire::test(ForcedPasswordReset::class, ['user' => $this->user]);
+    }
+
+    /**
+     * @return \Livewire\Testing\TestableLivewire
+     */
+    protected function verifiedComponent(): \Livewire\Testing\TestableLivewire
+    {
+        return $this->getComponent()
+            ->set('token', $this->getExpectedToken())
+            ->call('verify');
+    }
+
+    protected function getExpectedToken(): ?string
+    {
+        return Session::get('forcedPasswordReset.token');
+    }
+}


### PR DESCRIPTION
## Summary
Post-incident remediation. Invalidates every user's password by writing a sentinel value (`User::PASSWORD_RESET_SENTINEL = 'RESET_REQUIRED'`) that is not a valid bcrypt hash, so `Hash::check()` can never succeed against it. On the next login attempt, sentinel-state users are handed off to a new in-page Livewire flow (modelled on `Migrate`) where they verify by 6-digit email token and set a new password without leaving the site. No new database column.

Three commits, in order:
1. **Add forced password reset flow for sentinel-state users** — adds the sentinel constant, `LoginController` detection branch, `ForcedPasswordReset` Livewire component + views, and 18 feature tests. Dormant — no user has the sentinel yet, so this commit alone is a no-op in production.
2. **Invalidate all passwords post-incident** — runs the migration that flips every user into the sentinel state, nulls `remember_token`s, and truncates `password_resets` + `sessions`. Activates the flow.
3. **Snap back tampered `$verified` to prevent step-2 leak** — adds an `updatedVerified()` Livewire hook so a client flipping the public `$verified` property doesn't advance the view to step 2 (which would have leaked `$user->first_name` to anyone who knows a sentinel user's email). Defense-in-depth alongside the existing session-backed guard in `resetPassword()`.

## Security design notes
- Authoritative verified state lives in the session under `forcedPasswordReset.verified`, not in a public Livewire property. `resetPassword()` opens with `abort_unless(Session::get(...) === true, 403)`.
- `$user` is safe to trust because Livewire 2's `CannotBindToModelDataWithoutValidationRuleException` blocks rebinding Eloquent properties without an explicit rule — a test (`testLivewireBlocksRebindingTheUserProperty`) pins this.
- Password rules use `Illuminate\Validation\Rules\Password::defaults()` — same rule object the standard `ResetPasswordController` uses via the `ResetsPasswords` trait, so any project-wide policy tightening applies here too.
- Unknown emails still hit the standard invalid-credentials path, so the response doesn't leak which accounts are in the sentinel state.
- Legacy null-password users still hit the existing Livewire migrate wizard — the new flow does not interfere.

## Test plan
- [x] `php artisan test --filter=ForcedPasswordResetTest` → 19 passed.
- [x] After deploy, log in with a known account using your old (pre-incident) credentials → land on the `ForcedPasswordReset` view with the security-incident callout. Verify the email arrives, paste the 6-digit code, set a new password, end up authenticated on home.
- [x] Retry the same flow with a wrong email → standard "invalid credentials" error.
- [x] Legacy null-password account still hits the existing migrate wizard.
- [x] `users.password` column is uniformly `'RESET_REQUIRED'` post-migration; `remember_token` is null; `password_resets` and `sessions` tables are empty.

## Deploy notes
APP_KEY rotation (done by the operator) additionally invalidates encrypted session cookies and remember-token payloads.