### PR TITLE
Harden `Migrate` Livewire flow against `$verified` tampering

### DIFF
--- a/app/Http/Livewire/Migrate.php
+++ b/app/Http/Livewire/Migrate.php
@@ -41,6 +41,17 @@ class Migrate extends Component
 
     public $phone;
 
+    /**
+     * Public Livewire properties are hydrated from the client payload on
+     * every request, so $verified cannot be trusted as authorization
+     * state. The authoritative copy lives in the session under SESSION_KEY
+     * and is re-checked on every server action. The updatedVerified() hook
+     * snaps the public property back to the session value whenever the
+     * client tries to flip it, so the view also never advances to step 2
+     * unless verify() has succeeded server-side.
+     */
+    protected const SESSION_KEY = 'userMigration';
+
     protected function rules()
     {
         return [
@@ -63,13 +74,27 @@ class Migrate extends Component
             'token' => ['required', 'string', 'digits:6', Rule::in([$this->getExpectedToken()])],
         ]);
 
+        Session::put(self::SESSION_KEY . '.verified', true);
+
         $this->verified = true;
 
         $this->populateUser();
     }
 
+    /**
+     * Snap the public $verified property back to the session-backed truth
+     * on every client update, so a malicious client cannot flip it to true
+     * to skip the email-token step or advance the view to step 2.
+     */
+    public function updatedVerified()
+    {
+        $this->verified = Session::get(self::SESSION_KEY . '.verified', false) === true;
+    }
+
     public function saveUser()
     {
+        abort_unless(Session::get(self::SESSION_KEY . '.verified') === true, 403);
+
         $this->setBirthdate();
 
         $this->validate();
@@ -83,6 +108,8 @@ class Migrate extends Component
         $this->markUserEmailAsVerified();
 
         Auth::login(tap($this->user)->save());
+
+        Session::forget(self::SESSION_KEY);
 
         $this->redirect(route('home'));
     }

--- a/tests/Feature/MigrateUserTest.php
+++ b/tests/Feature/MigrateUserTest.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Auth\LoginController;
 use App\Http\Livewire\Migrate;
 use App\Models\User;
 use App\Notifications\VerificationToken;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Session;
@@ -399,6 +400,35 @@ class MigrateUserTest extends TestCase
         $this->submitUserInfo();
 
         $this->assertTrue($this->user->hasVerifiedEmail());
+    }
+
+    /** @test */
+    public function testCannotBypassVerificationByTamperingWithVerifiedProperty()
+    {
+        // $verified is a public Livewire property — a malicious client
+        // can flip it to true in the payload to try to skip the email-
+        // token step. The updatedVerified() hook snaps it back to the
+        // session-backed truth, and saveUser()'s abort_unless guard is
+        // the final boundary. Neither the account nor the auth state
+        // changes.
+        $this->testStep1()
+            ->set('verified', true)
+            ->set('class_course', 'EPL/S')
+            ->set('class_year', 2015)
+            ->set('password', 'password')
+            ->set('password_confirmation', 'password')
+            ->set('birthdate_year', 1994)
+            ->set('birthdate_month', 9)
+            ->set('birthdate_day', 22)
+            ->set('gender', 'M')
+            ->set('phone', '06 52 52 41 22')
+            ->call('saveUser')
+            ->assertForbidden();
+
+        $this->user->refresh();
+
+        $this->assertNull($this->user->password);
+        $this->assertFalse(Auth::check());
     }
 
     /**


### PR DESCRIPTION
## Summary
The legacy account-migration Livewire component (`App\Http\Livewire\Migrate`, used for null-password legacy users) has a weakness: `$verified` is a public Livewire property that the client can flip via the request payload to try to skip the email-token step.

Today, account takeover is prevented by accident — `$this->user` is `null` until `verify()` populates it, so `saveUser()` crashes on the null fill instead of writing the password. That defense-by-accident is fragile (a refactor that populates `$user` earlier would open up a real takeover) and the failure mode is an ugly 500 instead of a clean 403.

Adds explicit two-layer defense:

- `updatedVerified()` lifecycle hook snaps the public `$verified` property back to a session-backed truth on every client update, so the view never advances past step 1 unless `verify()` has succeeded server-side. Also prevents the view crash.
- `saveUser()` opens with `abort_unless(Session::get('userMigration.verified') === true, 403)` as the final boundary.
- Session is cleared on successful migration.

## Test plan
- [x] `php artisan test --filter=MigrateUserTest` → 33 passed (32 pre-existing + 1 new `testCannotBypassVerificationByTamperingWithVerifiedProperty`).